### PR TITLE
Fix STIG manager path

### DIFF
--- a/STIG-GOAT.ps1
+++ b/STIG-GOAT.ps1
@@ -718,7 +718,7 @@ if ($NonReportHosts.Count -gt 0) {
 
 # ======= COPY CHECKLISTS TO STIG-MANAGER DIR =======
 $MovedCKLCount   = 0
-$STIGManPrepDir  = Join-Path $CKLDir "_Stig-Manager"
+$STIGManPrepDir  = Join-Path $CKLDir "_STIG-Manager"
 
 # --- Archive setup ---
 $ArchiveDate     = Get-Date -Format 'yyyyMMdd'


### PR DESCRIPTION
## Summary
- keep `_STIG-Manager` directory name consistent

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68846f1d6328832ca63b93992dcf6d16