### PR TITLE
Fix StaggerSeconds calculation

### DIFF
--- a/STIG-GOAT.ps1
+++ b/STIG-GOAT.ps1
@@ -287,7 +287,11 @@ $TodaysLogs = Get-ChildItem -Path $ESTIGLogs -File | Where-Object {
 
 $HostCount = $TodaysLogs.Count
 $MaxStaggerSeconds = $HostCount * 3 # 3 seconds per host
-$StaggerSeconds = Get-Random -Minimum 0 -Maximum $MaxStaggerSeconds
+if ($MaxStaggerSeconds -lt 1) {
+    $StaggerSeconds = 0
+} else {
+    $StaggerSeconds = Get-Random -Minimum 0 -Maximum $MaxStaggerSeconds
+}
 
 # ================== ANSWER FILES UPDATE ==================
 


### PR DESCRIPTION
## Summary
- avoid calling `Get-Random` when there are no hosts

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688470e0cc68832caaea833361a1136f